### PR TITLE
Implement sbt keys and tasks for use as plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,21 @@
 An attempt to prototype the code to produce source distributions for
 [Apache Pekko](https://github.com/apache/incubator-pekko).
 
-This will ultimately be refactored so it can be called as an sbt task.
-
 * Some code comes from https://github.com/neva-dev/gitignore-file-filter
 * Some of the code was converted from the original Java to Scala - partially via IntelliJ autoconversion - some of that code needs work - to better follow Scala norms
 * Uses the .gitignore and some extra custom patterns to exclude files from the generated zip and tgz files
   * support for nested .gitignore files has not been retained (it can be added back if it is actually useful)
-* Outputs to target/dist directory
-* The `Main` class hard codes `val homeDirectory` - so anyone trying this out should adjust that to match their setup
+* Outputs to target/dist directory of the root project
+
+
+## sbt plugin
+
+sbt-source-dist is designed as an [AutoPlugin](https://www.scala-sbt.org/1.x/docs/Plugins.html) that is manually
+triggered which means that you need to explicitly enable it on your root project using 
+`.enablePlugins(SourceDistPlugin)`. If necessary one can override one of projects 
+[keys](/src/main/scala/com/github/pjfanning/sourcedist/SourceDistKeys.scala), i.e. if the name your project doesn't
+match the Apache project name you can do
+
+```sbt
+sourceDistName := "My Apache Project"
+```

--- a/src/main/scala/com/github/pjfanning/sourcedist/SourceDistGenerate.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/SourceDistGenerate.scala
@@ -1,20 +1,17 @@
-package com.github.pjfanning.sourcedist.ignorelist
+package com.github.pjfanning.sourcedist
 
+import ignorelist._
 import java.io.File
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 import sbt.io.IO
 
-object Main extends App {
-  val homeDirectory = "/Users/pj.fanning/code/incubator-pekko"
-  val namePrefix = "incubator-pekko"
-  // TODO remove hardcoded version - needs to become a param derived from git tag (or a property)
-  val versionString = "0.0.0"
-
-  generateSourceDists(homeDirectory, namePrefix, versionString)
-
-  private def generateSourceDists(homeDir: String, prefix: String, version: String): Unit = {
+private[sourcedist] object SourceDistGenerate {
+  private[sourcedist] def generateSourceDists(homeDir: String,
+                                              prefix: String,
+                                              targetDir: String,
+                                              version: String): Unit = {
     val baseDir = new File(homeDir)
 
     val ignoreList = new IgnoreList(baseDir)
@@ -30,11 +27,11 @@ object Main extends App {
 
     val dateTimeFormatter = DateTimeFormatter.BASIC_ISO_DATE
     val dateString = LocalDate.now().format(dateTimeFormatter)
-    val toFileDir = s"$homeDir/target/dist/"
     val baseFileName = s"$prefix-src-$version-$dateString"
-    val toZipFileName = s"$toFileDir/$baseFileName.zip"
-    val toTgzFileName = s"$toFileDir/$baseFileName.tgz"
-    IO.zip(files.map{file =>
+    val toZipFileName = s"$targetDir/$baseFileName.zip"
+    val toTgzFileName = s"$targetDir/$baseFileName.tgz"
+
+    IO.zip(files.map { file =>
       (file, removeBasePath(file.getAbsolutePath, homeDir))
     }, new File(toZipFileName), None)
     TarUtils.tgzFiles(toTgzFileName, files, homeDir)

--- a/src/main/scala/com/github/pjfanning/sourcedist/SourceDistKeys.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/SourceDistKeys.scala
@@ -1,0 +1,11 @@
+package com.github.pjfanning.sourcedist
+
+import sbt.{File, settingKey, taskKey}
+
+trait SourceDistKeys {
+  val sourceDistHomeDir = settingKey[File]("Home directory which contains the projects sources, defaults to project root directory")
+  val sourceDistTargetDir = settingKey[File]("Target directory where to create the archives, defaults dist folder under root project target folder")
+  val sourceDistVersion = settingKey[String]("The version to be used in the output archives, defaults to the root projects version")
+  val sourceDistName = settingKey[String]("The name to be used in the output archives, defaults to root projects name")
+  val sourceDistGenerate = taskKey[Unit]("Generate the source distribution packages")
+}

--- a/src/main/scala/com/github/pjfanning/sourcedist/SourceDistPlugin.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/SourceDistPlugin.scala
@@ -1,0 +1,28 @@
+package com.github.pjfanning.sourcedist
+
+import sbt._
+import Keys._
+import sbt.{AutoPlugin, Setting}
+
+object SourceDistPlugin extends AutoPlugin {
+  object autoImport extends SourceDistKeys
+
+  import autoImport._
+
+  def sourceDistGlobalSettings: Seq[Setting[_]] = Seq(
+    sourceDistHomeDir := baseDirectory.value,
+    sourceDistTargetDir := target.value / "dist",
+    sourceDistVersion := version.value,
+    sourceDistName := name.value,
+    sourceDistGenerate := SourceDistGenerate.generateSourceDists(
+      sourceDistHomeDir.value.getAbsolutePath,
+      sourceDistName.value,
+      sourceDistVersion.value,
+      sourceDistTargetDir.value.getAbsolutePath)
+  )
+
+  override def projectSettings: Seq[Setting[_]] = sourceDistGlobalSettings
+
+  override def trigger = noTrigger
+
+}


### PR DESCRIPTION
This PR is the initial implementation of this project as a proper sbt plugin. I have tested this locally and I can confirm that it works as expected, i.e.

```
pekko > sourceDistHomeDir
[info] /Users/mdedetrich/github/incubator-pekko
pekko > sourceDistTargetDir
[info] /Users/mdedetrich/github/incubator-pekko/target/dist
pekko > sourceDistName
[info] pekko-root
pekko > sourceDistVersion
[info] 0.0.0+26544-4c021960+20230202-1726-SNAPSHOT
```

The actual task to generate the archives also works, i.e.

```
[success] Total time: 3 s, completed 2 Feb 2023, 17:42:23
pekko > sourceDistGenerate
```

The files are then contained within `target/dist` as expected.

If you want to test this locally you can just do `sbt publishLocal` in this project, add the sbt plugin using `addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.0-SNAPSHOT")` and then you can add it into pekko root project with `.enablePlugins(SourceDistPlugin)`. Note that because the pekko-root project is actually called "pekko-root", as documented you need to override it so the final pekko root project would look like

```sbt
lazy val root = Project(id = "pekko", base = file("."))
  .aggregate(aggregatedProjects: _*)
  .enablePlugins(PublishRsyncPlugin)
  .settings(
    name := "pekko-root")
  .settings(rootSettings: _*)
  .settings(
    UnidocRoot.autoImport.unidocRootIgnoreProjects := Seq(
      remoteTests,
      benchJmh,
      protobuf,
      protobufV3,
      akkaScalaNightly,
      docs,
      serialversionRemoverPlugin))
  .settings(
    Compile / headerCreate / unmanagedSources := (baseDirectory.value / "project").**("*.scala").get,
    sourceDistName := "pekko")
  .settings(PekkoBuild.welcomeSettings)
  .enablePlugins(CopyrightHeaderForBuild)
  .enablePlugins(SourceDistPlugin)
```

Note that this is just the initial implementation, more work is still necessary, i.e. we have to handle the case where if a pre-existing archives already exist (should we overwrite and should we warn?). I also have done some slight refactoring of packages.