### PR TITLE
Clean up generating archives

### DIFF
--- a/src/main/scala/com/github/pjfanning/sourcedist/SourceDistGenerate.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/SourceDistGenerate.scala
@@ -29,14 +29,25 @@ private[sourcedist] object SourceDistGenerate {
     val dateTimeFormatter = DateTimeFormatter.BASIC_ISO_DATE
     val dateString = LocalDate.now().format(dateTimeFormatter)
     val baseFileName = s"$prefix-src-$version-$dateString"
-    val toZipFileName = s"$targetDir/$baseFileName.zip"
-    val toTgzFileName = s"$targetDir/$baseFileName.tgz"
+    val toZipFileName = new File(s"$targetDir/$baseFileName.zip")
+    val toTgzFileName = new File(s"$targetDir/$baseFileName.tgz")
+    println(s"$targetDir/$baseFileName.tgz")
 
-    logger.info(s"creating $toZipFileName")
+    if (toZipFileName.exists()) {
+      logger.info(s"Found previous zip artifact at $toZipFileName, recreating")
+      IO.delete(toZipFileName)
+    } else
+      logger.info(s"Creating zip archive at ${toZipFileName.getPath}")
+
     IO.zip(files.map { file =>
       (file, removeBasePath(file.getAbsolutePath, homeDir))
-    }, new File(toZipFileName), None)
-    logger.info(s"creating $toTgzFileName")
+    }, toZipFileName, None)
+
+    if (toTgzFileName.exists()) {
+      logger.info(s"Found previous tgz archive at ${toTgzFileName.getPath}, recreating")
+      IO.delete(toTgzFileName)
+    } else
+      logger.info(s"Creating tar archive at ${toTgzFileName.getPath}")
     TarUtils.tgzFiles(toTgzFileName, files, homeDir)
   }
 

--- a/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/TarUtils.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/TarUtils.scala
@@ -6,11 +6,8 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream
 import java.io.{BufferedOutputStream, File, FileInputStream, FileOutputStream, InputStream, OutputStream}
 
 object TarUtils {
-  def tgzFiles(tarFileName: String, filesToInclude: Seq[File], homeDir: String): Unit = {
-    val tarFile = new File(tarFileName)
-    new File(tarFileName).mkdirs()
-    if (tarFile.exists()) tarFile.delete()
-    val tarFileStream = new FileOutputStream(tarFileName)
+  def tgzFiles(tarFile: File, filesToInclude: Seq[File], homeDir: String): Unit = {
+    val tarFileStream = new FileOutputStream(tarFile)
     try {
       val buffOut = new BufferedOutputStream(tarFileStream)
       val gzOut = new GzipCompressorOutputStream(buffOut)


### PR DESCRIPTION
This PR does a few cleanups for generating the archives

* Improved logging, source-dist now detects if a previous artifacts happen to exist (doesn't happen now with snapshots but can happen with a full version)
  * Also will delete the artifact if it happens to exist previously
* Removed a redundant code that didn't do anything (see comment)
* Make `TarUtils.tgzFiles` accept a `File` instead of a `String`. This removes a lot of redundant calls to make a `new File`.

I tested this locally on Pekko and it works as expected.