### PR TITLE
Add and apply scalafmt

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,24 @@
+name: Scalafmt
+
+permissions: read-all
+
+on:
+  pull_request:
+    branches: ['**']
+
+jobs:
+  build:
+    name: Code is formatted
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v2
+        with:
+          version: '3.7.1'
+          arguments: '--list --mode diff-ref=origin/main'

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,11 @@
+version = 3.7.1
+runner.dialect = scala213
+preset = default
+align.preset = more
+maxColumn = 120
+project.git = true
+align.openParenDefnSite = true
+align.openParenCallSite = true
+align.arrowEnumeratorGenerator = true
+danglingParentheses.preset = true
+rewrite.rules = [RedundantBraces, RedundantParens]

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import org.typelevel.sbt.gha.JavaSpec.Distribution.Zulu
 
-name := "sbt-source-dist"
+name         := "sbt-source-dist"
 organization := "com.github.pjfanning"
-description := "sbt plugin to generate source distributions"
+description  := "sbt plugin to generate source distributions"
 
 sbtPlugin := true
 
@@ -12,7 +12,7 @@ ThisBuild / scalaVersion := "2.12.17"
 
 libraryDependencies ++= Seq(
   "org.apache.commons" % "commons-compress" % "1.22",
-  "org.scalatest" %% "scalatest" % "3.2.15" % Test
+  "org.scalatest"     %% "scalatest"        % "3.2.15" % Test
 )
 
 homepage := Some(url("https://github.com/pjfanning/sbt-source-dist"))
@@ -20,12 +20,12 @@ homepage := Some(url("https://github.com/pjfanning/sbt-source-dist"))
 licenses := Seq("APL2" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt"))
 
 developers := List(
-  Developer(id="pjfanning", name="PJ Fanning", email="", url=url("https://github.com/pjfanning")),
-  Developer(id="mdedetrich", name="Matthew de Detrich", email="", url=url("https://github.com/mdedetrich"))
+  Developer(id = "pjfanning", name = "PJ Fanning", email = "", url = url("https://github.com/pjfanning")),
+  Developer(id = "mdedetrich", name = "Matthew de Detrich", email = "", url = url("https://github.com/mdedetrich"))
 )
 
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec(Zulu, "8"))
-ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("test")))
+ThisBuild / githubWorkflowBuild        := Seq(WorkflowStep.Sbt(List("test")))
 ThisBuild / githubWorkflowPublishTargetBranches := Seq(
   RefPredicate.Equals(Ref.Branch("main")),
   RefPredicate.StartsWith(Ref.Tag("v"))
@@ -35,10 +35,10 @@ ThisBuild / githubWorkflowPublish := Seq(
   WorkflowStep.Sbt(
     List("ci-release"),
     env = Map(
-      "PGP_PASSPHRASE" -> "${{ secrets.PGP_PASSPHRASE }}",
-      "PGP_SECRET" -> "${{ secrets.PGP_SECRET }}",
-      "SONATYPE_PASSWORD" -> "${{ secrets.SONATYPE_PASSWORD }}",
-      "SONATYPE_USERNAME" -> "${{ secrets.SONATYPE_USERNAME }}",
+      "PGP_PASSPHRASE"      -> "${{ secrets.PGP_PASSPHRASE }}",
+      "PGP_SECRET"          -> "${{ secrets.PGP_SECRET }}",
+      "SONATYPE_PASSWORD"   -> "${{ secrets.SONATYPE_PASSWORD }}",
+      "SONATYPE_USERNAME"   -> "${{ secrets.SONATYPE_USERNAME }}",
       "CI_SNAPSHOT_RELEASE" -> "+publishSigned"
     )
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,4 @@
-addSbtPlugin("org.typelevel" % "sbt-typelevel-sonatype-ci-release" % "0.5.0-M9")
-
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
-
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.4")
-
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
+addSbtPlugin("org.typelevel"    % "sbt-typelevel-sonatype-ci-release" % "0.5.0-M9")
+addSbtPlugin("com.github.sbt"   % "sbt-ci-release"                    % "1.5.11")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates"                       % "0.6.4")
+addSbtPlugin("org.scalameta"    % "sbt-scalafmt"                      % "2.5.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,5 @@ addSbtPlugin("org.typelevel" % "sbt-typelevel-sonatype-ci-release" % "0.5.0-M9")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.4")
+
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")

--- a/src/main/scala/com/github/pjfanning/sourcedist/SourceDistGenerate.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/SourceDistGenerate.scala
@@ -13,10 +13,11 @@ private[sourcedist] object SourceDistGenerate {
                                               prefix: String,
                                               version: String,
                                               targetDir: String,
-                                              logger: ManagedLogger): Unit = {
+                                              logger: ManagedLogger
+  ): Unit = {
     val baseDir = new File(homeDir)
 
-    val ignoreList = new IgnoreList(baseDir)
+    val ignoreList           = new IgnoreList(baseDir)
     val customIgnorePatterns = new PathPatternList("")
     customIgnorePatterns.add("target/")
     customIgnorePatterns.add(".git/")
@@ -27,10 +28,11 @@ private[sourcedist] object SourceDistGenerate {
     val files = getIncludedFiles(baseDir, ignoreList)
 
     val dateTimeFormatter = DateTimeFormatter.BASIC_ISO_DATE
-    val dateString = LocalDate.now().format(dateTimeFormatter)
-    val baseFileName = s"$prefix-src-$version-$dateString"
-    val targetDirFile = new File(targetDir)
-    if (!targetDirFile.exists()) IO.createDirectory(targetDirFile)
+    val dateString        = LocalDate.now().format(dateTimeFormatter)
+    val baseFileName      = s"$prefix-src-$version-$dateString"
+    val targetDirFile     = new File(targetDir)
+    if (!targetDirFile.exists())
+      IO.createDirectory(targetDirFile)
     val toZipFile = new File(targetDirFile, s"$baseFileName.zip")
     val toTgzFile = new File(targetDirFile, s"$baseFileName.tgz")
 
@@ -41,8 +43,11 @@ private[sourcedist] object SourceDistGenerate {
       logger.info(s"Creating zip archive at ${toZipFile.getPath}")
 
     IO.zip(files.map { file =>
-      (file, removeBasePath(file.getAbsolutePath, homeDir))
-    }, toZipFile, None)
+             (file, removeBasePath(file.getAbsolutePath, homeDir))
+           },
+           toZipFile,
+           None
+    )
 
     if (toTgzFile.exists()) {
       logger.info(s"Found previous tgz archive at ${toTgzFile.getPath}, recreating")

--- a/src/main/scala/com/github/pjfanning/sourcedist/SourceDistKeys.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/SourceDistKeys.scala
@@ -3,9 +3,13 @@ package com.github.pjfanning.sourcedist
 import sbt.{File, settingKey, taskKey}
 
 trait SourceDistKeys {
-  val sourceDistHomeDir = settingKey[File]("Home directory which contains the projects sources, defaults to project root directory")
-  val sourceDistTargetDir = settingKey[File]("Target directory where to create the archives, defaults dist folder under root project target folder")
-  val sourceDistVersion = settingKey[String]("The version to be used in the output archives, defaults to the root projects version")
+  val sourceDistHomeDir =
+    settingKey[File]("Home directory which contains the projects sources, defaults to project root directory")
+  val sourceDistTargetDir = settingKey[File](
+    "Target directory where to create the archives, defaults dist folder under root project target folder"
+  )
+  val sourceDistVersion =
+    settingKey[String]("The version to be used in the output archives, defaults to the root projects version")
   val sourceDistName = settingKey[String]("The name to be used in the output archives, defaults to root projects name")
   val sourceDistGenerate = taskKey[Unit]("Generate the source distribution packages")
 }

--- a/src/main/scala/com/github/pjfanning/sourcedist/SourceDistPlugin.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/SourceDistPlugin.scala
@@ -10,16 +10,17 @@ object SourceDistPlugin extends AutoPlugin {
   import autoImport._
 
   def sourceDistGlobalSettings: Seq[Setting[_]] = Seq(
-    sourceDistHomeDir := baseDirectory.value,
+    sourceDistHomeDir   := baseDirectory.value,
     sourceDistTargetDir := target.value / "dist",
-    sourceDistVersion := version.value,
-    sourceDistName := name.value,
+    sourceDistVersion   := version.value,
+    sourceDistName      := name.value,
     sourceDistGenerate := SourceDistGenerate.generateSourceDists(
       homeDir = sourceDistHomeDir.value.getAbsolutePath,
       prefix = sourceDistName.value,
       version = sourceDistVersion.value,
       targetDir = sourceDistTargetDir.value.getAbsolutePath,
-      logger = streams.value.log)
+      logger = streams.value.log
+    )
   )
 
   override def projectSettings: Seq[Setting[_]] = sourceDistGlobalSettings

--- a/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/ExcludeUtils.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/ExcludeUtils.scala
@@ -43,26 +43,24 @@ import java.io.{File, FileNotFoundException, IOException}
 import java.nio.charset.StandardCharsets
 
 private[ignorelist] object ExcludeUtils {
- def readExcludeFile(file: File, basePath: String): PathPatternList = {
+  def readExcludeFile(file: File, basePath: String): PathPatternList = {
     if (file == null) throw new NullPointerException("file is null")
     if (!file.exists || !file.canRead) throw new FileNotFoundException(s"Failed to find ${file.getAbsolutePath}")
     if (!file.canRead) throw new IOException(s"Cannot read ${file.getAbsolutePath}")
-    val src = Source.fromFile(file, StandardCharsets.UTF_8.name())
+    val src  = Source.fromFile(file, StandardCharsets.UTF_8.name())
     val list = new PathPatternList(basePath)
-    try {
-      for (line <- src.getLines) {
+    try
+      for (line <- src.getLines)
         if (line.nonEmpty && !line.startsWith("#")) {
           list.add(line)
         }
-      }
-    } finally {
+    finally
       src.close()
-    }
     list
   }
 
   def getRelativePath(wd: File, file: File): String = {
-    val skip = if (file.getPath.length > wd.getPath.length) 1 else 0
+    val skip    = if (file.getPath.length > wd.getPath.length) 1 else 0
     var relName = file.getPath.substring(wd.getPath.length + skip)
     if (File.separatorChar != '/') relName = relName.replace(File.separatorChar, '/')
     relName

--- a/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/IgnoreList.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/IgnoreList.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable
 
 class IgnoreList(private val rootDir: File) {
   private val patternListCache = mutable.Map[File, PathPatternList]()
-  private val patternDefaults = mutable.Buffer[PathPatternList]()
+  private val patternDefaults  = mutable.Buffer[PathPatternList]()
   addPatterns(rootDir)
 
   def addPatterns(dir: File): IgnoreList = addPatterns(dir, "")
@@ -19,11 +19,11 @@ class IgnoreList(private val rootDir: File) {
   }
 
   def isExcluded(file: File): Boolean = {
-    val filePath = ExcludeUtils.getRelativePath(rootDir, file)
+    val filePath    = ExcludeUtils.getRelativePath(rootDir, file)
     val pathBuilder = new java.lang.StringBuilder(filePath.length)
-    val stack = patternDefaults.toIndexedSeq
-    var loop = true
-    var result = false
+    val stack       = patternDefaults.toIndexedSeq
+    var loop        = true
+    var result      = false
     while (loop) {
       val pathOffset = filePath.indexOf('/', pathBuilder.length + 1)
       val (offset, isDirectory) = if (pathOffset == -1) {
@@ -33,14 +33,13 @@ class IgnoreList(private val rootDir: File) {
       }
       pathBuilder.insert(pathBuilder.length, filePath, pathBuilder.length, offset)
       val currentPath = pathBuilder.toString
-      val iter = stack.reverseIterator
+      val iter        = stack.reverseIterator
       while (loop && iter.hasNext) {
         val patterns = iter.next()
         patterns.findPattern(currentPath, isDirectory) match {
-          case Some(pattern) => {
+          case Some(pattern) =>
             result = pattern.isExclude
             loop = false
-          }
           case _ =>
         }
       }
@@ -55,14 +54,12 @@ class IgnoreList(private val rootDir: File) {
   private def getDirectoryPattern(dir: File, dirPath: String): PathPatternList =
     getPatternList(new File(dir, GitIgnore.FILE_NAME), dirPath)
 
-  private def getPatternList(file: File, basePath: String): PathPatternList = {
+  private def getPatternList(file: File, basePath: String): PathPatternList =
     patternListCache.get(file) match {
       case Some(list) => list
-      case _ => {
+      case _ =>
         val list = ExcludeUtils.readExcludeFile(file, basePath)
         patternListCache.put(file, list)
         list
-      }
     }
-  }
 }

--- a/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/PathPattern.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/PathPattern.scala
@@ -39,31 +39,29 @@
 package com.github.pjfanning.sourcedist.ignorelist
 
 object PathPattern {
-  def create(pattern: String): PathPattern = {
+  def create(pattern: String): PathPattern =
     if (hasNoWildcards(pattern, 0, pattern.length)) new PathPattern.NoWildcardPathPattern(pattern)
     else new PathPattern.WildcardPathPattern(pattern)
-  }
 
   private def isWildcard(c: Char) = c == '*' || c == '[' || c == '?' || c == '\\'
 
-  private def hasNoWildcards(pattern: String, from: Int, to: Int): Boolean = {
+  private def hasNoWildcards(pattern: String, from: Int, to: Int): Boolean =
     (from until to).collectFirst { case i =>
       !isWildcard(pattern.charAt(i))
     }.isEmpty
-  }
 
   private class NoWildcardPathPattern(pattern: String) extends PathPattern(pattern) {
-    override protected def matchesFileName(path: String): Boolean = {
+    override protected def matchesFileName(path: String): Boolean =
       if (path.length > pattern.length && path.charAt(path.length - pattern.length - 1) != '/') {
         false
       } else {
         path.endsWith(pattern)
       }
-    }
 
     override protected def matchesPathName(path: String, basePath: String): Boolean = {
-      val baseLength = if (basePath.length > 0) basePath.length + 1
-      else 0
+      val baseLength =
+        if (basePath.length > 0) basePath.length + 1
+        else 0
       path.length - baseLength == pattern.length && path.startsWith(pattern, baseLength)
     }
   }

--- a/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/PathPatternList.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/PathPatternList.scala
@@ -47,11 +47,10 @@ class PathPatternList(private val basePath: String) {
     else patterns = patterns.+:(pattern)
   }
 
-  def findPattern(path: String, isDirectory: Boolean): Option[PathPattern] = {
+  def findPattern(path: String, isDirectory: Boolean): Option[PathPattern] =
     patterns.find { p =>
       p.matches(path, isDirectory, basePath)
     }
-  }
 
   override def toString: String = {
     val builder = new StringBuilder(getClass.getSimpleName)

--- a/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/TarUtils.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/TarUtils.scala
@@ -10,32 +10,30 @@ object TarUtils {
     val tarFileStream = new FileOutputStream(tarFile)
     try {
       val buffOut = new BufferedOutputStream(tarFileStream)
-      val gzOut = new GzipCompressorOutputStream(buffOut)
-      val tos = new TarArchiveOutputStream(gzOut)
+      val gzOut   = new GzipCompressorOutputStream(buffOut)
+      val tos     = new TarArchiveOutputStream(gzOut)
       tos.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX)
       filesToInclude.sortBy(_.getAbsolutePath).foreach { f =>
         val truncatedFileName = removeBasePath(f.getAbsolutePath, homeDir)
-        val tarEntry = new TarArchiveEntry(truncatedFileName)
+        val tarEntry          = new TarArchiveEntry(truncatedFileName)
         tarEntry.setSize(f.length())
         tos.putArchiveEntry(tarEntry)
         val fis = new FileInputStream(f)
-        try {
+        try
           copyLarge(fis, tos)
-        } finally {
+        finally
           fis.close()
-        }
         tos.closeArchiveEntry()
       }
       tos.close()
-    } finally {
+    } finally
       tarFileStream.close()
-    }
   }
 
   private def copyLarge(inputStream: InputStream, outputStream: OutputStream): Long = {
     val buffer = new Array[Byte](8192)
-    var count = 0L
-    var n = inputStream.read(buffer)
+    var count  = 0L
+    var n      = inputStream.read(buffer)
     while (n != -1) {
       outputStream.write(buffer, 0, n)
       count += n


### PR DESCRIPTION
Adds and applies scalafmt. Unlike with Pekko, the scalafmt configuration used here is a lot more basic/conservative (this was a deliberate choice on my part). Also technically the project is not specific to Pekko (even though I do think that Pekko is the only Apache project using sbt).

If you want me to update the configuration just let me know and I can rebase the PR with changes.