### PR TITLE
Auto trigger plugin and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,33 @@ An attempt to prototype the code to produce source distributions for
 [Apache Pekko](https://github.com/apache/incubator-pekko).
 
 * Some code comes from https://github.com/neva-dev/gitignore-file-filter
-* Some of the code was converted from the original Java to Scala - partially via IntelliJ autoconversion - some of that code needs work - to better follow Scala norms
+* Some of the code was converted from the original Java to Scala - partially via IntelliJ autoconversion - some of that
+  code needs work - to better follow Scala norms
 * Uses the .gitignore and some extra custom patterns to exclude files from the generated zip and tgz files
-  * support for nested .gitignore files has not been retained (it can be added back if it is actually useful)
+    * support for nested .gitignore files has not been retained (it can be added back if it is actually useful)
 * Outputs to target/dist directory of the root project
-
 
 ## sbt plugin
 
-sbt-source-dist is designed as an [AutoPlugin](https://www.scala-sbt.org/1.x/docs/Plugins.html) that is manually
-triggered which means that you need to explicitly enable it on your root project using 
-`.enablePlugins(SourceDistPlugin)`. If necessary one can override one of projects 
-[keys](/src/main/scala/com/github/pjfanning/sourcedist/SourceDistKeys.scala), i.e. if the name your project doesn't
-match the Apache project name you can do
+sbt-source-dist is designed as an [AutoPlugin](https://www.scala-sbt.org/1.x/docs/Plugins.html) that immediately
+triggers onto the root project. If necessary one can override one of
+projects [keys](/src/main/scala/com/github/pjfanning/sourcedist/SourceDistKeys.scala), i.e. if the name of your project
+doesn't your Apache projects name you can do
 
 ```sbt
 sourceDistName := "My Apache Project"
 ```
 
-Once the plugin is enabled, you can generate the source distributions using
+If you have an explicit root project then you can do the following
+
+```sbt
+val root = Project(id = "root", base = file(".")).settings(
+  sourceDistName := "My Apache Project"
+)
+```
+
+You can then generate the source distribution using
+
 ```
 sbt sourceDistGenerate
 ```

--- a/src/main/scala/com/github/pjfanning/sourcedist/SourceDistPlugin.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/SourceDistPlugin.scala
@@ -12,11 +12,11 @@ object SourceDistPlugin extends AutoPlugin {
 
   import autoImport._
 
-  def sourceDistGlobalSettings: Seq[Setting[_]] = Seq(
-    sourceDistHomeDir   := baseDirectory.value,
-    sourceDistTargetDir := target.value / "dist",
-    sourceDistVersion   := version.value,
-    sourceDistName      := name.value,
+  private[sourcedist] lazy val sourceDistSettings: Seq[Setting[_]] = Seq(
+    sourceDistHomeDir   := (LocalRootProject / baseDirectory).value,
+    sourceDistTargetDir := (LocalRootProject / target).value / "dist",
+    sourceDistVersion   := (LocalRootProject / version).value,
+    sourceDistName      := (LocalRootProject / name).value,
     sourceDistSuffix    := LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE),
     sourceDistGenerate := SourceDistGenerate.generateSourceDists(
       homeDir = sourceDistHomeDir.value.getAbsolutePath,
@@ -28,8 +28,8 @@ object SourceDistPlugin extends AutoPlugin {
     )
   )
 
-  override def projectSettings: Seq[Setting[_]] = sourceDistGlobalSettings
+  override lazy val projectSettings: Seq[Setting[_]] = sourceDistSettings
 
-  override def trigger = noTrigger
+  override def trigger = allRequirements
 
 }

--- a/src/sbt-test/sbt-source-dist/simple-explicit-root-project/build.sbt
+++ b/src/sbt-test/sbt-source-dist/simple-explicit-root-project/build.sbt
@@ -1,0 +1,6 @@
+val root = Project(id = "root", base = file(".")).settings(
+  scalaVersion     := "2.13.10",
+  version          := "0.1.9",
+  sourceDistName   := "incubator-pekko",
+  sourceDistSuffix := "20230331"
+)

--- a/src/sbt-test/sbt-source-dist/simple-explicit-root-project/project/plugins.sbt
+++ b/src/sbt-test/sbt-source-dist/simple-explicit-root-project/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-source-dist/simple-explicit-root-project/src/main/scala/hello.scala
+++ b/src/sbt-test/sbt-source-dist/simple-explicit-root-project/src/main/scala/hello.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("hello")
+}

--- a/src/sbt-test/sbt-source-dist/simple-explicit-root-project/test
+++ b/src/sbt-test/sbt-source-dist/simple-explicit-root-project/test
@@ -1,0 +1,7 @@
+> sourceDistGenerate
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.zip
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.zip.sha256
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.zip.sha512
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.tgz
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.tgz.sha256
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.tgz.sha512

--- a/src/sbt-test/sbt-source-dist/simple-implicit-name/build.sbt
+++ b/src/sbt-test/sbt-source-dist/simple-implicit-name/build.sbt
@@ -1,4 +1,4 @@
 scalaVersion     := "2.13.10"
 version          := "0.1.9"
-sourceDistName   := "incubator-pekko"
+name             := "incubator-pekko"
 sourceDistSuffix := "20230331"

--- a/src/sbt-test/sbt-source-dist/simple-implicit-name/project/plugins.sbt
+++ b/src/sbt-test/sbt-source-dist/simple-implicit-name/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-source-dist/simple-implicit-name/src/main/scala/hello.scala
+++ b/src/sbt-test/sbt-source-dist/simple-implicit-name/src/main/scala/hello.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("hello")
+}

--- a/src/sbt-test/sbt-source-dist/simple-implicit-name/test
+++ b/src/sbt-test/sbt-source-dist/simple-implicit-name/test
@@ -1,0 +1,7 @@
+> sourceDistGenerate
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.zip
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.zip.sha256
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.zip.sha512
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.tgz
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.tgz.sha256
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.tgz.sha512


### PR DESCRIPTION
This change does 2 things

* Makes the plugin trigger automatically which means that `.enablePlugins(SourceDistPlugin)` is no longer neccessary
* Scopes all of the settings to be in sbt's global scope (see https://www.scala-sbt.org/1.x/docs/Scopes.html)

The reasons behind the changes are documented in `README.md` but the summary is that this plugin only makes sense in the `Global` scope since its just archiving the source files of the entire project, i.e. there is never going to be a case where individual sbt sub projects will need to override specific keys relating to this plugin. For additional context, examples of keys that exist in `Global` scope are `concurrentRestrictions` (which again only makes sense globally since this key controls how many tests you run concurrently in sbt globally).

One consequence of this PR is that when overriding this plugins settings you also need to do it globally, i.e. with Pekko you would have to do `Global / sourceDistName := "incubator-pekko"` (this has also been documented). A `simple-with-name` test has also been added so that we test for the case where `sourceDistName` is automatically derived from a sbt projects `name := something`.

I also published this plugin locally and tested it with Pekko and I can confirm its working with the above mentioned change. The additional new lines are because of scalafmt (current `main` branch is not correctly formatted).