### PR TITLE
Add inliner settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,10 @@ description  := "sbt plugin to generate source distributions"
 sbtPlugin := true
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
+scalacOptions ++= Seq(
+  "-opt:l:inline",
+  "-opt-inline-from:<sources>"
+)
 
 ThisBuild / scalaVersion := "2.12.17"
 


### PR DESCRIPTION
Adds inliner settings, which might bring some marginal performance improvements. Note that `"-opt-inline-from:<sources>"` means that scalac will only inline sources from this project and hence its what is documented should be used for libraries (see https://www.lightbend.com/blog/scala-inliner-optimizer, its also the default for [sbt-scala-module](https://github.com/scala/sbt-scala-module/blob/4a5714280ef2a47fe925e0d82911673416660fc7/src/main/scala/ScalaModulePlugin.scala#L57))