### PR TITLE
Make all keys lazy vals and side effecting keys TaskKey's

### DIFF
--- a/src/main/scala/com/github/pjfanning/sourcedist/SourceDistKeys.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/SourceDistKeys.scala
@@ -1,20 +1,20 @@
 package com.github.pjfanning.sourcedist
 
-import sbt.{File, settingKey, taskKey}
+import sbt.{File, SettingKey, TaskKey, settingKey, taskKey}
 
 trait SourceDistKeys {
-  val sourceDistHomeDir =
+  lazy val sourceDistHomeDir: SettingKey[File] =
     settingKey[File]("Home directory which contains the projects sources, defaults to project root directory")
-  val sourceDistTargetDir = settingKey[File](
+  lazy val sourceDistTargetDir: SettingKey[File] = settingKey[File](
     "Target directory where to create the archives, defaults dist folder under root project target folder"
   )
-  val sourceDistVersion =
+  lazy val sourceDistVersion: SettingKey[String] =
     settingKey[String]("The version to be used in the output archive file names, defaults to the root projects version")
-  val sourceDistName = settingKey[String](
+  lazy val sourceDistName: SettingKey[String] = settingKey[String](
     "The name to be used as the prefix in the output archive file names, defaults to root projects name"
   )
-  val sourceDistSuffix = settingKey[String](
+  lazy val sourceDistSuffix: TaskKey[String] = taskKey[String](
     "The suffix to be used in the output archive file names, defaults to today's date in YYMMDD format"
   )
-  val sourceDistGenerate = taskKey[Unit]("Generate the source distribution packages")
+  lazy val sourceDistGenerate: TaskKey[Unit] = taskKey[Unit]("Generate the source distribution packages")
 }


### PR DESCRIPTION
This PR does the following things

* `SettingKey`'s by default are lazy and cached, which means they only get computed once after sbt's resolution mechanism is done. For pure values this is fine but for side effects (i.e. getting the date and in our case generating the file from that date) the key should be executed each time on demand and the right abstraction for this is a `TaskKey`.
* Use lazy vals for all of the keys, this is idiomatic since for sbt plugins since they only need to be evaluated once.
* Since they are public, adds explicit types for the keys.

Nice explanation of the difference between tasks and settings is here https://medium.com/@awesomeorji/sbt-for-the-absolute-beginner-2-settings-and-tasks-6f3b00be1a81


@pjfanning If you feel like the timing is right (i.e. no future changes are likely to be done) feel free to make a new release after this PR merge and then I can start going around Pekko projects update/add the plugin.