### PR TITLE
Move utility methods outside of ignorelist package

### DIFF
--- a/src/main/scala/com/github/pjfanning/sourcedist/ShaUtils.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/ShaUtils.scala
@@ -1,4 +1,4 @@
-package com.github.pjfanning.sourcedist.ignorelist
+package com.github.pjfanning.sourcedist
 
 import java.io.{File, FileInputStream, FileOutputStream, InputStream, OutputStreamWriter}
 import java.nio.charset.StandardCharsets
@@ -32,7 +32,7 @@ object ShaUtils {
     }
   }
 
-  private def convertBytesToHexadecimal(byteArray: Array[Byte]): String = {
+  private[sourcedist] def convertBytesToHexadecimal(byteArray: Array[Byte]): String = {
     val hexBuilder = new StringBuilder()
     byteArray.foreach { b =>
       val decimal: Int = b & 0xff

--- a/src/main/scala/com/github/pjfanning/sourcedist/TarUtils.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/TarUtils.scala
@@ -1,4 +1,4 @@
-package com.github.pjfanning.sourcedist.ignorelist
+package com.github.pjfanning.sourcedist
 
 import org.apache.commons.compress.archivers.tar.{TarArchiveEntry, TarArchiveOutputStream}
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream
@@ -26,7 +26,7 @@ object TarUtils {
       }
     }
 
-  private def copyLarge(inputStream: InputStream, outputStream: OutputStream): Long = {
+  private[sourcedist] def copyLarge(inputStream: InputStream, outputStream: OutputStream): Long = {
     val buffer = new Array[Byte](8192)
     var count  = 0L
     var n      = inputStream.read(buffer)

--- a/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/ExcludeUtils.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/ExcludeUtils.scala
@@ -36,13 +36,14 @@
  * pjfanning elects to include this software in this distribution
  * under the CDDL license.
  */
-package com.github.pjfanning.sourcedist.ignorelist
+package com.github.pjfanning.sourcedist
+package ignorelist
 
 import scala.io.Source
 import java.io.{File, FileNotFoundException, IOException}
 import java.nio.charset.StandardCharsets
 
-private[ignorelist] object ExcludeUtils {
+private[sourcedist] object ExcludeUtils {
   def readExcludeFile(file: File, basePath: String): PathPatternList = {
     if (file == null) throw new NullPointerException("file is null")
     if (!file.exists || !file.canRead) throw new FileNotFoundException(s"Failed to find ${file.getAbsolutePath}")

--- a/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/PathPattern.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/PathPattern.scala
@@ -36,7 +36,8 @@
  * pjfanning elects to include this software in this distribution
  * under the CDDL license.
  */
-package com.github.pjfanning.sourcedist.ignorelist
+package com.github.pjfanning.sourcedist
+package ignorelist
 
 object PathPattern {
   def create(pattern: String): PathPattern =

--- a/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/PathPatternList.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/ignorelist/PathPatternList.scala
@@ -36,7 +36,8 @@
  * pjfanning elects to include this software in this distribution
  * under the CDDL license.
  */
-package com.github.pjfanning.sourcedist.ignorelist
+package com.github.pjfanning.sourcedist
+package ignorelist
 
 class PathPatternList(private val basePath: String) {
   private var patterns = Seq[PathPattern]()

--- a/src/main/scala/com/github/pjfanning/sourcedist/package.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/package.scala
@@ -1,6 +1,6 @@
-package com.github.pjfanning.sourcedist
+package com.github.pjfanning
 
-package object ignorelist {
+package object sourcedist {
   private[sourcedist] def removeBasePath(fileName: String, basePath: String): String = {
     val truncated = if (fileName.startsWith(basePath)) {
       fileName.substring(basePath.length)

--- a/src/test/scala/com/github/pjfanning/sourcedist/UtilSpec.scala
+++ b/src/test/scala/com/github/pjfanning/sourcedist/UtilSpec.scala
@@ -1,4 +1,4 @@
-package com.github.pjfanning.sourcedist.ignorelist
+package com.github.pjfanning.sourcedist
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers


### PR DESCRIPTION
PR does the following things

* Move utility methods that have nothing to do with ignore list out of the `ignorelist` package
* In cases of a bare `private`, change to package private instead since we can test the methods
* Preference to use `sourcedist` package rather than `ignorelist` package since its more open