### PR TITLE
Fix issue with multi project builds

### DIFF
--- a/src/main/scala/com/github/pjfanning/sourcedist/SourceDistPlugin.scala
+++ b/src/main/scala/com/github/pjfanning/sourcedist/SourceDistPlugin.scala
@@ -13,22 +13,22 @@ object SourceDistPlugin extends AutoPlugin {
   import autoImport._
 
   private[sourcedist] lazy val sourceDistSettings: Seq[Setting[_]] = Seq(
-    sourceDistHomeDir   := (LocalRootProject / baseDirectory).value,
-    sourceDistTargetDir := (LocalRootProject / target).value / "dist",
-    sourceDistVersion   := (LocalRootProject / version).value,
-    sourceDistName      := (LocalRootProject / name).value,
-    sourceDistSuffix    := LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE),
-    sourceDistGenerate := SourceDistGenerate.generateSourceDists(
-      homeDir = sourceDistHomeDir.value.getAbsolutePath,
-      prefix = sourceDistName.value,
-      version = sourceDistVersion.value,
-      suffix = sourceDistSuffix.value,
-      targetDir = sourceDistTargetDir.value.getAbsolutePath,
+    LocalRootProject / sourceDistHomeDir   := (LocalRootProject / baseDirectory).value,
+    LocalRootProject / sourceDistTargetDir := (LocalRootProject / target).value / "dist",
+    LocalRootProject / sourceDistVersion   := (LocalRootProject / version).value,
+    LocalRootProject / sourceDistName      := (LocalRootProject / name).value,
+    LocalRootProject / sourceDistSuffix    := LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE),
+    LocalRootProject / sourceDistGenerate := SourceDistGenerate.generateSourceDists(
+      homeDir = (LocalRootProject / sourceDistHomeDir).value.getAbsolutePath,
+      prefix = (LocalRootProject / sourceDistName).value,
+      version = (LocalRootProject / sourceDistVersion).value,
+      suffix = (LocalRootProject / sourceDistSuffix).value,
+      targetDir = (LocalRootProject / sourceDistTargetDir).value.getAbsolutePath,
       logger = streams.value.log
     )
   )
 
-  override lazy val projectSettings: Seq[Setting[_]] = sourceDistSettings
+  override lazy val buildSettings: Seq[Setting[_]] = sourceDistSettings
 
   override def trigger = allRequirements
 

--- a/src/sbt-test/sbt-source-dist/multi-project/build.sbt
+++ b/src/sbt-test/sbt-source-dist/multi-project/build.sbt
@@ -1,0 +1,9 @@
+name             := "project"
+scalaVersion     := "2.13.10"
+version          := "0.1.9"
+sourceDistName   := "incubator-pekko"
+sourceDistSuffix := "20230331"
+
+lazy val subOne = Project(id = "sub", file("sub")).settings(
+  sourceDistSuffix := "20230331"
+)

--- a/src/sbt-test/sbt-source-dist/multi-project/project/plugins.sbt
+++ b/src/sbt-test/sbt-source-dist/multi-project/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-source-dist/multi-project/src/main/scala/hello.scala
+++ b/src/sbt-test/sbt-source-dist/multi-project/src/main/scala/hello.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("hello")
+}

--- a/src/sbt-test/sbt-source-dist/multi-project/test
+++ b/src/sbt-test/sbt-source-dist/multi-project/test
@@ -1,0 +1,14 @@
+> sourceDistGenerate
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.zip
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.zip.sha256
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.zip.sha512
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.tgz
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.tgz.sha256
+$ exists target/dist/incubator-pekko-src-0.1.9-20230331.tgz.sha512
+
+$ absent target/dist/project-src-0.1.9-20230331.zip
+$ absent target/dist/project-src-0.1.9-20230331.zip.sha256
+$ absent target/dist/project-src-0.1.9-20230331.zip.sha512
+$ absent target/dist/project-src-0.1.9-20230331.tgz
+$ absent target/dist/project-src-0.1.9-20230331.tgz.sha256
+$ absent target/dist/project-src-0.1.9-20230331.tgz.sha512


### PR DESCRIPTION
So in my last PR at https://github.com/pjfanning/sbt-source-dist/pull/15 I managed to create a regression specifically for sbt builds that have multiple sbt projects. It turns out that if you use `projectSettings` in conjunction with `trigger = allRequirements` then the `AutoPlugin` will add the keys to **every** project, meaning that when you run `sbt sourceDistGenerate` then it will generate a source for every single sbt sub project rather than just the intended root project.

The solution to this is to use `buildSettings` (which only execute once per build) however only set the keys for `LocalRootProject` (which is the root project), for sbt builds that have don't have multiple sbt projects the behaviour is unchanged (even when it comes to overriding values).

A test that verifies this behaviour has been added, without the fix the `mutli-project` scripted test will do the following

```
[info] [info] Creating zip archive at /private/var/folders/x6/_f2z1gl567xc_03ds0v6q1p00000gn/T/sbt_62070424/target/dist/project-src-0.1.9-20230215.zip
[info] [info] Creating zip archive at /private/var/folders/x6/_f2z1gl567xc_03ds0v6q1p00000gn/T/sbt_62070424/target/dist/incubator-pekko-src-0.1.9-20230331.zip
[info] [info] Creating tar archive at /private/var/folders/x6/_f2z1gl567xc_03ds0v6q1p00000gn/T/sbt_62070424/target/dist/incubator-pekko-src-0.1.9-20230331.tgz
[info] [info] Creating tar archive at /private/var/folders/x6/_f2z1gl567xc_03ds0v6q1p00000gn/T/sbt_62070424/target/dist/project-src-0.1.9-20230215.tgz
```
which demonstrates the problem (i.e. `project-src-0.1.9-20230215.zip` files being created) however with the fix only the `incubator-pekko-src-0.1.9-20230331.tgz` is created. I also published this locally and tested it to make sure it works with pekko core (which is a build that has multiple sbt projects)