### PR TITLE
Update scalafmt version and github action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,6 @@ jobs:
           persist-credentials: false
 
       - name: Check project is formatted
-        uses: jrouly/scalafmt-native-action@v2
+        uses: jrouly/scalafmt-native-action@v3
         with:
-          version: '3.7.11'
           arguments: '--list --mode diff-ref=origin/main'

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.7.11
+version = 3.7.17
 runner.dialect = scala213
 preset = default
 align.preset = more


### PR DESCRIPTION
Updates both the scalafmt version and also the scalafmt native github action which means we don't have it hardcoded in multiple places